### PR TITLE
Add more configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,36 @@ export let config = {
     accessToken: '<DEFAULT ACCESS TOKEN>'
 };
 ```
-Leave out `userId` and `accessToken` to attempt registration as guest.
+Leave out `userId` and `accessToken` to attempt registration as guest.   
+#### Complete list of options:
+*  `baseUrl` (*string*) - Base URL of homeserver - **Required**
+*  `roomId` (*string*) - The internal ID of default room - **Required** 
+*  `userId` (*string*) - The ID of default user            
+    Ignore to register as guest
+*  `accessToken` (*string*) - Access token of default user     
+    Ignore to register as guest
+*  `readOnly` (*boolean*) - If the client is in read-only mode    
+    - `true`
+    - `false` (default)        
+    Disables `msgComposer` and `roomsList` (unless overriden)
+*  `theme` (*string*) - Theme of the client
+    - `'dark'` - Dark theme (default)
+    - `'light'` - Light theme
+*  `highlight` (*string*) - Highlight color  
+    - `'pink'` - Pink highlights (default)  
+    - `'green'` - Green highlights
+*  `roomHeader` (*boolean*) - If room header should be displayed        
+    - `true` (default)
+    - `false`          
+*  `roomsList` (*boolean*) - If rooms list should be displayed (overrides `readOnly`)      
+    - `true` (default)
+    - `false`          
+*  `msgComposer` (*boolean*) - If message composer should be displayed (overrides `readOnly`)          
+    - `true` (default)
+    - `false`          
+*  `whitelist` (*Array*) - Whitelisted origins         
+    Ignore to allow all origins
+*  `signInPrompt` (*string*) - Show sign in prompts    
+    - `'none'` - Never show (default)
+    - `'guests'` - Show if signed in as guest
+    - `'all'` - Always show

--- a/classes/message-handler.js
+++ b/classes/message-handler.js
@@ -6,7 +6,7 @@ import EventEmitter from 'events';
  * @param   {Array} origins - List of whitelisted origin domains
  */
 export default class MessageHandler extends EventEmitter{
-    constructor(origins=['null']) {
+    constructor(origins) {
         super();
         this.origins = origins;
 
@@ -26,8 +26,8 @@ export default class MessageHandler extends EventEmitter{
             origin = event.originalEvent.origin;
         }
 
-        // If origin is in whitelist
-        if ( this.origins.includes(origin) ) {
+        // If origin is in whitelist or if whitelist is undefined
+        if ( this.origins === undefined || this.origins.includes(origin) ) {
             let data = event.data;
 
             // Parse data

--- a/components/client.jsx
+++ b/components/client.jsx
@@ -268,7 +268,7 @@ export default class Client extends Component{
                             onClick={this.onSelectRoom} />)}
                         <TimelinePanel homeserver={homeserver}
                             room={this.state.room} client={this.client}
-                            replyTo={this.replyTo} > 
+                            replyTo={this.replyTo} showTools={this.state.msgComposer} > 
                             {this.state.reply && this.state.msgComposer ? 
                                 <ReplyPopup homeserver={homeserver} 
                                     mxEvent={this.state.reply} client={this.client} 

--- a/components/event-tile.jsx
+++ b/components/event-tile.jsx
@@ -12,13 +12,15 @@ import Sanitizer from '../classes/sanitizer.js';
  * @param   {object} mxEvent - The event object
  * @param   {object} client - The matrix client object
  * @param   {func} replyTo - Callback for setting reply
+ * @param   {boolean} showTools - If event toolbar should be shown
  */
 export default class EventTile extends PureComponent {
     static propTypes = {
         homeserver: PropTypes.string.isRequired, // Homeserver URL
         mxEvent: PropTypes.object.isRequired, // Event object
         client: PropTypes.object.isRequired, // Client object
-        replyTo: PropTypes.func.isRequired // Callback for setting reply
+        replyTo: PropTypes.func.isRequired, // Callback for setting reply
+        showTools: PropTypes.bool.isRequired // If event toolbar should be shown
     };
 
     // Consume theme context
@@ -59,7 +61,7 @@ export default class EventTile extends PureComponent {
             <li>
                 <div className={`list-panel-item msg-body-${theme.theme}`}>
                     <Avatar imgUrl={avatarUrl} size={32} name={userId} />
-                    <MessageToolbar mxEvent={this.props.mxEvent} replyTo={this.props.replyTo} />
+                    {this.props.showTools && <MessageToolbar mxEvent={this.props.mxEvent} replyTo={this.props.replyTo} />}
                     <div className='msg-data'>
                         <h4>{name} <i className='text-muted'>{userId}</i></h4>
                         <p>

--- a/components/timeline-panel.jsx
+++ b/components/timeline-panel.jsx
@@ -79,18 +79,17 @@ export default class TimelinePanel extends PureComponent {
 
             let timelineList = document.getElementById('timeline-list');
             let newHeight = timelineList.clientHeight;
-
-            // Only if not already at the top of timeline
-            if (newHeight !== oldHeight) {
-                let timelineBody = document.getElementById('timeline-body');
-                
-                // Scroll to original position (position += diff in height)
-                timelineBody.scrollTop += timelineList.clientHeight - oldHeight;
-                
-                // If scrolled to top or not fully scrolled to top
-                if (timelineBody.scrollTop <= 0) {
-                    this.loadPrevious(newHeight);
-                }
+            let timelineBody = document.getElementById('timeline-body');
+            
+            // Scroll to original position (position += diff in height)
+            let change = newHeight - oldHeight;
+            timelineBody.scrollTop += change;
+            
+            // If scrolled to top or not fully scrolled to top or
+            // if change in height is less than threshold (300)
+            if (timelineBody.scrollTop <= 0 || 
+                change < 300) {
+                this.loadPrevious(newHeight);
             }
         });
     }

--- a/components/timeline-panel.jsx
+++ b/components/timeline-panel.jsx
@@ -11,6 +11,7 @@ import ThemeContext from './theme-context.jsx';
  * @param   {object} client - The client object
  * @param   {array} children - Children of room timeline
  * @param   {func} replyTo - Callback for setting reply 
+ * @param   {boolean} showTools - If event toolbar should be shown
  */
 export default class TimelinePanel extends PureComponent {
     static propTypes = {
@@ -18,7 +19,8 @@ export default class TimelinePanel extends PureComponent {
         room: PropTypes.object, // Room object
         client: PropTypes.object, // Client object
         children: PropTypes.array, // Children of the room body
-        replyTo: PropTypes.func // Callback for setting reply
+        replyTo: PropTypes.func, // Callback for setting reply
+        showTools: PropTypes.bool // If event toolbar should be shown
     };
 
     constructor(props) {
@@ -121,7 +123,8 @@ export default class TimelinePanel extends PureComponent {
                     <EventTile key={event.event.event_id} 
                         homeserver={this.props.homeserver}
                         mxEvent={event} client={this.props.client}
-                        replyTo={this.props.replyTo} />
+                        replyTo={this.props.replyTo} 
+                        showTools={this.props.showTools} />
                 ); 
             }
         }

--- a/docs.md
+++ b/docs.md
@@ -4,13 +4,15 @@ This is a version of the Matrix client intended to be embedded within iframes of
 Currently, the client supports:   
 * List of joined rooms that can be selected 
 * Live room timeline events
-* Support for image based messages     
+* Support for image based messages  
+* Support for markdown in messages   
 * Message composer and ability to send messages to a room
 * Dark and light themes for the client
 * Changeable highlight colors
-* Toggleable room header and room timeline components
+* Toggleable message composer, room header, and room timeline components
 * `postMessage` interface for sending commands from the parent window    
 * Support for guest mode
+* Support for read-only mode
 
 More features to be added soon.
 ## Usage
@@ -46,6 +48,38 @@ export let config = {
 };
 ```
 Leave out `userId` and `accessToken` to attempt registration as guest.
+#### Complete list of options:
+*  `baseUrl` (*string*) - Base URL of homeserver - **Required**
+*  `roomId` (*string*) - The internal ID of default room - **Required** 
+*  `userId` (*string*) - The ID of default user            
+    Ignore to register as guest
+*  `accessToken` (*string*) - Access token of default user     
+    Ignore to register as guest
+*  `readOnly` (*boolean*) - If the client is in read-only mode    
+    - `true`
+    - `false` (default)        
+    Disables `msgComposer` and `roomsList` (unless overriden)
+*  `theme` (*string*) - Theme of the client
+    - `'dark'` - Dark theme (default)
+    - `'light'` - Light theme
+*  `highlight` (*string*) - Highlight color  
+    - `'pink'` - Pink highlights (default)  
+    - `'green'` - Green highlights
+*  `roomHeader` (*boolean*) - If room header should be displayed        
+    - `true` (default)
+    - `false`          
+*  `roomsList` (*boolean*) - If rooms list should be displayed (overrides `readOnly`)      
+    - `true` (default)
+    - `false`          
+*  `msgComposer` (*boolean*) - If message composer should be displayed (overrides `readOnly`)          
+    - `true` (default)
+    - `false`          
+*  `whitelist` (*Array*) - Whitelisted origins         
+    Ignore to allow all origins
+*  `signInPrompt` (*string*) - Show sign in prompts    
+    - `'none'` - Never show (default)
+    - `'guests'` - Show if signed in as guest
+    - `'all'` - Always show
 ### Using the `postMessage` interface
 All messages will follow this format
 ```js

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-var path = require('path');
+const path = require('path');
 
 module.exports = {
     entry: './app.js',


### PR DESCRIPTION
## Options added in this PR:
* readOnly
* theme
* highlight
* roomHeader
* roomsList
* msgComposer
* whitelist
* signInPrompt
## Complete list of options:
*  `baseUrl` (*string*) - Base URL of homeserver - **Required**
*  `roomId` (*string*) - The internal ID of default room - **Required** 
*  `userId` (*string*) - The ID of default user            
    Ignore to register as guest
*  `accessToken` (*string*) - Access token of default user     
    Ignore to register as guest
*  `readOnly` (*boolean*) - If the client is in read-only mode    
    - `true`
    - `false` (default)        
    Disables `msgComposer` and `roomsList` (unless overriden)
*  `theme` (*string*) - Theme of the client
    - `'dark'` - Dark theme (default)
    - `'light'` - Light theme
*  `highlight` (*string*) - Highlight color  
    - `'pink'` - Pink highlights (default)  
    - `'green'` - Green highlights
*  `roomHeader` (*boolean*) - If room header should be displayed        
    - `true` (default)
    - `false`          
*  `roomsList` (*boolean*) - If rooms list should be displayed (overrides `readOnly`)      
    - `true` (default)
    - `false`          
*  `msgComposer` (*boolean*) - If message composer should be displayed (overrides `readOnly`)          
    - `true` (default)
    - `false`          
*  `whitelist` (*Array*) - Whitelisted origins         
    Ignore to allow all origins
*  `signInPrompt` (*string*) - Show sign in prompts    
    - `'none'` - Never show (default)
    - `'guests'` - Show if signed in as guest
    - `'all'` - Always show