### PR TITLE
Add modal to sign in or register as guest from read-only mode

### DIFF
--- a/components/client.jsx
+++ b/components/client.jsx
@@ -86,7 +86,9 @@ export default class Client extends Component{
         this.messageHandler.on('login', this.login);
 
         // Refs
+        this.signInModal = createRef();
         this.receiptsModal = createRef();
+        this.continueModal = createRef();
 
         if (!props.accessToken || !props.userId) {
             // If any accessToken or userId is absent
@@ -408,7 +410,7 @@ export default class Client extends Component{
         return (
             <ThemeContext.Provider value={{theme: this.state.theme, highlight: this.state.highlight}}>
                 <div className={`client bg-primary-${this.state.theme}`}>
-                    <Modal visible={siPrompt} title='Sign in'>
+                    <Modal visible={siPrompt} title='Sign in' ref={this.signInModal}>
                         <SignInForm client={this.client} setUser={this.setUser} />
                     </Modal>
                     
@@ -417,6 +419,16 @@ export default class Client extends Component{
                             <ul className='user-list'>
                                 {this.list}
                             </ul>
+                        </div>
+                    </Modal>
+
+                    <Modal visible={false} title='Sign in to continue' ref={this.continueModal}>
+                        <div className='form'>
+                            <b>Please sign in or register a guest account to send a message.</b>
+                            <div className='form-button-panel'>
+                                <button>Sign in</button>
+                                <button>Register as guest</button>
+                            </div>
                         </div>
                     </Modal>
 

--- a/components/message-composer.jsx
+++ b/components/message-composer.jsx
@@ -11,13 +11,15 @@ import Sanitizer from '../classes/sanitizer.js';
  * @param   {MatrixClient} client - The client object
  * @param   {object} mxEvent - Event to reply to
  * @param   {func} unsetReply - Callback to unset reply
+ * @param   {func} openContinueModal - Callback to open continue dialog box
  */
 export default class MessageComposer extends PureComponent {
     static propTypes = {
         roomId: PropTypes.string.isRequired, // Current room ID
         client: PropTypes.object.isRequired, // Client object
         mxEvent: PropTypes.object, // Event to reply to
-        unsetReply: PropTypes.func.isRequired // Callback to unset reply
+        unsetReply: PropTypes.func.isRequired, // Callback to unset reply
+        openContinueModal: PropTypes.func // Callback to open continue dialog box
     };
 
     constructor(props) {
@@ -79,6 +81,11 @@ export default class MessageComposer extends PureComponent {
     sendMessage() {
         if (this.state.value.length <= 0) return;
 
+        if (this.props.openContinueModal) {
+            this.props.openContinueModal();
+            return;
+        }
+        
         this.setState({
             value: '',
             busy: true

--- a/components/modal.jsx
+++ b/components/modal.jsx
@@ -23,6 +23,7 @@ export default class Modal extends PureComponent {
         };
 
         this.close = this.close.bind(this);
+        this.open = this.open.bind(this);
     }
 
     close() {

--- a/styles/layout.scss
+++ b/styles/layout.scss
@@ -217,6 +217,15 @@ body {
     margin: 0;
 }
 
+.form-button-panel {
+    width: 50%;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-evenly;
+    align-items: center;
+    margin-top: 5px;
+}
+
 .error-msg {
     font-size: 14px;
     color: #f00;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34343421/89731533-65a3b100-da65-11ea-8dab-35574783ae07.png)
When `readOnly` is set `true` and `msgComposer` is also overridden to `true`, attempting to send a message opens this dialogue box which either leads to the sign-in modal or the user joining the current room as a guest.